### PR TITLE
feat(tools): add cache controls and typed responses

### DIFF
--- a/OpenData.Mcp.Server.Tests/BaseToolsTests.cs
+++ b/OpenData.Mcp.Server.Tests/BaseToolsTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenData.Mcp.Server.Tools;
+using Xunit;
+
+namespace OpenData.Mcp.Server.Tests;
+
+public class BaseToolsTests
+{
+    [Fact]
+    public async Task GetResult_ReturnsJsonAndRawData()
+    {
+        var handler = new RecordingHandler((_, _) => SuccessResponse("{\"value\":42}"));
+        var tools = CreateTools(handler);
+
+        var response = await tools.ExecuteAsync("https://example.com/data");
+
+        Assert.True(response.Success);
+        Assert.True(response.Json.HasValue);
+        Assert.Equal("{\"value\":42}", response.RawContent);
+
+        var typed = response.GetData<TestPayload>();
+        Assert.NotNull(typed);
+        Assert.Equal(42, typed!.Value);
+    }
+
+    [Fact]
+    public async Task GetResult_CachesResponsesByDefault()
+    {
+        var handler = new RecordingHandler((_, call) => SuccessResponse($"{{\"call\":{call}}}"));
+        var tools = CreateTools(handler);
+
+        var first = await tools.ExecuteAsync("https://example.com/cache");
+        var second = await tools.ExecuteAsync("https://example.com/cache");
+
+        Assert.Equal(1, handler.CallCount);
+        Assert.Equal(first.RawContent, second.RawContent);
+    }
+
+    [Fact]
+    public async Task GetResult_RespectsDisabledCache()
+    {
+        var handler = new RecordingHandler((_, call) => SuccessResponse($"{{\"call\":{call}}}"));
+        var tools = CreateTools(handler);
+
+        await tools.ExecuteAsync("https://example.com/no-cache", BaseTools.CacheSettings.Disabled);
+        await tools.ExecuteAsync("https://example.com/no-cache", BaseTools.CacheSettings.Disabled);
+
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetResult_AllowsCustomExpiration()
+    {
+        var handler = new RecordingHandler((_, call) => SuccessResponse($"{{\"call\":{call}}}"));
+        var tools = CreateTools(handler);
+
+        await tools.ExecuteAsync("https://example.com/ttl", BaseTools.CacheSettings.FromTtl(TimeSpan.FromMilliseconds(25)));
+        await Task.Delay(60);
+        await tools.ExecuteAsync("https://example.com/ttl", BaseTools.CacheSettings.FromTtl(TimeSpan.FromMilliseconds(25)));
+
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetResult_RetriesTransientFailures()
+    {
+        var handler = new RecordingHandler((_, call) =>
+        {
+            if (call == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                {
+                    Content = new StringContent(string.Empty)
+                };
+            }
+
+            return SuccessResponse("{\"value\":1}");
+        });
+
+        var tools = CreateTools(handler);
+        var response = await tools.ExecuteAsync("https://example.com/retry");
+
+        Assert.True(response.Success);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetResult_ReturnsErrorAfterRetries()
+    {
+        var handler = new RecordingHandler((_, _) => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            ReasonPhrase = "Server Error",
+            Content = new StringContent(string.Empty)
+        });
+
+        var tools = CreateTools(handler);
+        var response = await tools.ExecuteAsync("https://example.com/fail");
+
+        Assert.False(response.Success);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Contains("HTTP request failed", response.Error);
+        Assert.Equal(BaseTools.MaxRetryAttempts, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetResult_ReturnsRawForNonJson()
+    {
+        const string rss = "<rss><channel></channel></rss>";
+        var handler = new RecordingHandler((_, _) => SuccessResponse(rss, "application/rss+xml"));
+        var tools = CreateTools(handler);
+
+        var response = await tools.ExecuteAsync("https://example.com/rss");
+
+        Assert.True(response.Success);
+        Assert.False(response.Json.HasValue);
+        Assert.Equal(rss, response.RawContent);
+        Assert.Null(response.GetData<TestPayload>());
+    }
+
+    private static HttpResponseMessage SuccessResponse(string content, string mediaType = "application/json")
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content, Encoding.UTF8, mediaType)
+        };
+    }
+
+    private static TestBaseTools CreateTools(HttpMessageHandler handler)
+    {
+        var factory = new TestHttpClientFactory(handler);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        return new TestBaseTools(factory, cache);
+    }
+
+    private sealed record TestPayload(int Value);
+
+    private sealed class TestBaseTools : BaseTools
+    {
+        public TestBaseTools(IHttpClientFactory httpClientFactory, IMemoryCache cache)
+            : base(httpClientFactory, NullLogger.Instance, cache)
+        {
+        }
+
+        public Task<McpToolResponse> ExecuteAsync(string url, CacheSettings? settings = null)
+            => GetResult(url, settings);
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public TestHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(_handler, disposeHandler: false)
+            {
+                Timeout = Timeout.InfiniteTimeSpan
+            };
+        }
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, int, HttpResponseMessage> _responseFactory;
+
+        public RecordingHandler(Func<HttpRequestMessage, int, HttpResponseMessage> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var call = ++CallCount;
+            var response = _responseFactory(request, call);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/OpenData.Mcp.Server.Tests/OpenData.Mcp.Server.Tests.csproj
+++ b/OpenData.Mcp.Server.Tests/OpenData.Mcp.Server.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenData.Mcp.Server\OpenData.Mcp.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OpenData.Mcp.Server.Tests/ToolCachingTests.cs
+++ b/OpenData.Mcp.Server.Tests/ToolCachingTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenData.Mcp.Server;
+using OpenData.Mcp.Server.Tools;
+using Xunit;
+
+namespace OpenData.Mcp.Server.Tests;
+
+public class ToolCachingTests
+{
+    [Fact]
+    public async Task MembersTools_UsesCachedResponses()
+    {
+        var handler = new RecordingHandler((request, call) => SuccessResponse($"{{\"call\":{call}}}"));
+        var factory = new TestHttpClientFactory(handler);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var tools = new MembersTools(factory, NullLogger<MembersTools>.Instance, cache);
+
+        await tools.GetAnsweringBodiesAsync();
+        await tools.GetAnsweringBodiesAsync();
+
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task NowTools_DisablesCaching()
+    {
+        var handler = new RecordingHandler((request, call) => SuccessResponse($"{{\"call\":{call}}}"));
+        var factory = new TestHttpClientFactory(handler);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var tools = new NowTools(factory, NullLogger<NowTools>.Instance, cache);
+
+        await tools.HappeningNowInCommonsAsync();
+        await tools.HappeningNowInCommonsAsync();
+
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    private static HttpResponseMessage SuccessResponse(string content)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public TestHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(_handler, disposeHandler: false)
+            {
+                Timeout = Timeout.InfiniteTimeSpan
+            };
+        }
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, int, HttpResponseMessage> _responseFactory;
+
+        public RecordingHandler(Func<HttpRequestMessage, int, HttpResponseMessage> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var call = ++CallCount;
+            var response = _responseFactory(request, call);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/OpenData.Mcp.Server/Tools/BaseTools.cs
+++ b/OpenData.Mcp.Server/Tools/BaseTools.cs
@@ -7,14 +7,46 @@ namespace OpenData.Mcp.Server.Tools
 {
     /// <summary>
     /// Structured response for MCP tools containing either data or error information.
+    /// Provides both raw content and parsed JSON accessors for consumers.
     /// </summary>
     public class McpToolResponse
     {
+        private static readonly JsonSerializerOptions DefaultSerializerOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
         public string Url { get; set; } = string.Empty;
-        public object? Data { get; set; }
+        public JsonElement? Json { get; set; }
+        public string? RawContent { get; set; }
         public string? Error { get; set; }
         public int? StatusCode { get; set; }
         public bool Success => Error == null;
+
+        /// <summary>
+        /// Materialises the response payload into a strongly typed object when possible.
+        /// </summary>
+        public T? GetData<T>(JsonSerializerOptions? options = null)
+        {
+            if (Json is JsonElement jsonElement)
+            {
+                return jsonElement.Deserialize<T>(options ?? DefaultSerializerOptions);
+            }
+
+            if (!string.IsNullOrEmpty(RawContent))
+            {
+                try
+                {
+                    return JsonSerializer.Deserialize<T>(RawContent, options ?? DefaultSerializerOptions);
+                }
+                catch (JsonException)
+                {
+                    // If parsing fails we simply return the default value.
+                }
+            }
+
+            return default;
+        }
     }
 
     /// <summary>
@@ -29,11 +61,21 @@ namespace OpenData.Mcp.Server.Tools
 
         // HTTP configuration constants
         protected static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(30);
-        protected const int MaxRetryAttempts = 3;
+        public const int MaxRetryAttempts = 3;
         protected static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
 
         // Cache configuration constants
         protected static readonly TimeSpan CacheExpiration = TimeSpan.FromMinutes(15);
+
+        /// <summary>
+        /// Allows individual tool calls to override cache behaviour.
+        /// </summary>
+        public record CacheSettings(bool Enabled, TimeSpan? AbsoluteExpirationRelativeToNow = null)
+        {
+            public static CacheSettings Default { get; } = new(true, null);
+            public static CacheSettings Disabled { get; } = new(false, null);
+            public static CacheSettings FromTtl(TimeSpan ttl) => new(true, ttl);
+        }
 
         protected BaseTools(IHttpClientFactory httpClientFactory, ILogger logger, IMemoryCache cache)
         {
@@ -65,129 +107,120 @@ namespace OpenData.Mcp.Server.Tools
         /// Returns structured response with URL and data/error information.
         /// </summary>
         /// <param name="url">The URL to make the request to</param>
+        /// <param name="cacheSettings">Optional cache settings for the request</param>
         /// <returns>Structured response containing URL and either data or error details</returns>
-        protected async Task<McpToolResponse> GetResult(string url)
+        protected async Task<McpToolResponse> GetResult(string url, CacheSettings? cacheSettings = null)
         {
-            // Check cache first
-            if (Cache.TryGetValue(url, out McpToolResponse? cachedResponse) && cachedResponse != null)
+            var settings = cacheSettings ?? CacheSettings.Default;
+
+            if (settings.Enabled && Cache.TryGetValue(url, out McpToolResponse? cachedResponse) && cachedResponse != null)
             {
                 Logger.LogInformation("Retrieved cached result for {Url}", url);
                 return cachedResponse;
             }
 
-            for (int attempt = 0; attempt < MaxRetryAttempts; attempt++)
+            for (var attempt = 0; attempt < MaxRetryAttempts; attempt++)
             {
                 try
                 {
                     using var httpClient = HttpClientFactory.CreateClient();
                     httpClient.Timeout = HttpTimeout;
-                    
-                    Logger.LogInformation("Making HTTP request to {Url} (attempt {Attempt}/{MaxAttempts})", 
-                        url, attempt + 1, MaxRetryAttempts);
-                    
+
+                    Logger.LogInformation(
+                        "Making HTTP request to {Url} (attempt {Attempt}/{MaxAttempts})",
+                        url,
+                        attempt + 1,
+                        MaxRetryAttempts);
+
                     var response = await httpClient.GetAsync(url);
-                    
+
                     if (response.IsSuccessStatusCode)
                     {
                         var responseContent = await response.Content.ReadAsStringAsync();
                         Logger.LogInformation("Successfully retrieved data from {Url}", url);
 
-                        // Try to parse as JSON, fallback to string if it fails
-                        object? data;
-                        try
-                        {
-                            data = JsonSerializer.Deserialize<object>(responseContent);
-                        }
-                        catch (JsonException)
-                        {
-                            data = responseContent;
-                        }
+                        var result = CreateSuccessResponse(url, responseContent);
 
-                        var result = new McpToolResponse { Url = url, Data = data };
+                        if (settings.Enabled)
+                        {
+                            var cacheEntryOptions = new MemoryCacheEntryOptions
+                            {
+                                AbsoluteExpirationRelativeToNow = settings.AbsoluteExpirationRelativeToNow ?? CacheExpiration
+                            };
 
-                        // Cache successful results
-                        Cache.Set(url, result, CacheExpiration);
+                            Cache.Set(url, result, cacheEntryOptions);
+                        }
 
                         return result;
                     }
-                    
+
                     if (IsTransientFailure(response.StatusCode))
                     {
-                        Logger.LogWarning("Transient failure for {Url}: {StatusCode}. Attempt {Attempt}/{MaxAttempts}", 
-                            url, response.StatusCode, attempt + 1, MaxRetryAttempts);
-                        
+                        Logger.LogWarning(
+                            "Transient failure for {Url}: {StatusCode}. Attempt {Attempt}/{MaxAttempts}",
+                            url,
+                            response.StatusCode,
+                            attempt + 1,
+                            MaxRetryAttempts);
+
                         if (attempt < MaxRetryAttempts - 1)
                         {
                             await Task.Delay(RetryDelay * (attempt + 1));
                             continue;
                         }
                     }
-                    
+
                     var errorMessage = $"HTTP request failed with status {response.StatusCode}: {response.ReasonPhrase}";
                     Logger.LogError("Final failure for {Url}: {StatusCode}", url, response.StatusCode);
-                    return new McpToolResponse
-                    {
-                        Url = url,
-                        Error = errorMessage,
-                        StatusCode = (int)response.StatusCode
-                    };
+                    return CreateErrorResponse(url, errorMessage, (int)response.StatusCode);
                 }
                 catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
                 {
-                    Logger.LogWarning("Request to {Url} timed out. Attempt {Attempt}/{MaxAttempts}", 
-                        url, attempt + 1, MaxRetryAttempts);
-                    
+                    Logger.LogWarning(
+                        "Request to {Url} timed out. Attempt {Attempt}/{MaxAttempts}",
+                        url,
+                        attempt + 1,
+                        MaxRetryAttempts);
+
                     if (attempt < MaxRetryAttempts - 1)
                     {
                         await Task.Delay(RetryDelay * (attempt + 1));
                         continue;
                     }
-                    
+
                     var timeoutError = "Request timed out after multiple attempts";
                     Logger.LogError("Request to {Url} timed out after all retry attempts", url);
-                    return new McpToolResponse
-                    {
-                        Url = url,
-                        Error = timeoutError
-                    };
+                    return CreateErrorResponse(url, timeoutError);
                 }
                 catch (HttpRequestException ex)
                 {
-                    Logger.LogWarning(ex, "HTTP request exception for {Url}. Attempt {Attempt}/{MaxAttempts}", 
-                        url, attempt + 1, MaxRetryAttempts);
-                    
+                    Logger.LogWarning(
+                        ex,
+                        "HTTP request exception for {Url}. Attempt {Attempt}/{MaxAttempts}",
+                        url,
+                        attempt + 1,
+                        MaxRetryAttempts);
+
                     if (attempt < MaxRetryAttempts - 1)
                     {
                         await Task.Delay(RetryDelay * (attempt + 1));
                         continue;
                     }
-                    
+
                     var networkError = $"Network error: {ex.Message}";
                     Logger.LogError(ex, "Network error for {Url} after all retry attempts", url);
-                    return new McpToolResponse
-                    {
-                        Url = url,
-                        Error = networkError
-                    };
+                    return CreateErrorResponse(url, networkError);
                 }
                 catch (Exception ex)
                 {
                     Logger.LogError(ex, "Unexpected error for {Url}", url);
-                    return new McpToolResponse
-                    {
-                        Url = url,
-                        Error = $"Unexpected error: {ex.Message}"
-                    };
+                    return CreateErrorResponse(url, $"Unexpected error: {ex.Message}");
                 }
             }
 
-            return new McpToolResponse
-            {
-                Url = url,
-                Error = "Maximum retry attempts exceeded"
-            };
+            return CreateErrorResponse(url, "Maximum retry attempts exceeded");
         }
-        
+
         /// <summary>
         /// Determines if an HTTP status code represents a transient failure that should be retried.
         /// </summary>
@@ -203,6 +236,44 @@ namespace OpenData.Mcp.Server.Tools
                    statusCode == HttpStatusCode.GatewayTimeout;
         }
 
-      
+        private static McpToolResponse CreateSuccessResponse(string url, string content)
+        {
+            var json = TryParseJson(content);
+
+            return new McpToolResponse
+            {
+                Url = url,
+                Json = json,
+                RawContent = content
+            };
+        }
+
+        private static McpToolResponse CreateErrorResponse(string url, string error, int? statusCode = null)
+        {
+            return new McpToolResponse
+            {
+                Url = url,
+                Error = error,
+                StatusCode = statusCode
+            };
+        }
+
+        private static JsonElement? TryParseJson(string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return null;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(content);
+                return document.RootElement.Clone();
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/OpenData.Mcp.Server/Tools/CoreTools.cs
+++ b/OpenData.Mcp.Server/Tools/CoreTools.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using OpenData.Mcp.Server.Tools;
@@ -15,7 +15,7 @@ namespace OpenData.Mcp.Server
             return Task.FromResult(new McpToolResponse
             {
                 Url = "core://hello-parliament",
-                Data = GetSystemPrompt()
+                RawContent = GetSystemPrompt()
             });
         }
 
@@ -25,7 +25,7 @@ namespace OpenData.Mcp.Server
             return Task.FromResult(new McpToolResponse
             {
                 Url = "core://goodbye-parliament",
-                Data = GetGoodbyePrompt()
+                RawContent = GetGoodbyePrompt()
             });
         }
 
@@ -36,7 +36,7 @@ namespace OpenData.Mcp.Server
         {
             return @"You are a helpful assistant that answers questions using only data from UK Parliament MCP servers.
                 When the session begins, introduce yourself with a brief message such as:
-                ""Hello! I'm a parliamentary data assistant. I can help answer questions using official data from the UK Parliament MCP APIs. Just ask me something, and I'll fetch what I can — and I'll always show you which sources I used.""
+                ""Hello! I'm a parliamentary data assistant. I can help answer questions using official data from the UK Parliament MCP APIs. Just ask me something, and I'll fetch what I can � and I'll always show you which sources I used.""
                 When responding to user queries, you must:
                 Only retrieve and use data from the MCP API endpoints this server provides.
                 Avoid using any external sources or inferred knowledge.

--- a/OpenData.Mcp.Server/Tools/NowTools.cs
+++ b/OpenData.Mcp.Server/Tools/NowTools.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using OpenData.Mcp.Server.Tools;
@@ -15,14 +15,14 @@ namespace OpenData.Mcp.Server
         public async Task<McpToolResponse> HappeningNowInCommonsAsync()
         {
             var url = $"{NowApiBase}/Message/message/CommonsMain/current";
-            return await GetResult(url);
+            return await GetResult(url, CacheSettings.Disabled);
         }
 
         [McpServerTool(ReadOnly = true, Idempotent = true, OpenWorld = false), Description("Get live information about what's currently happening in the House of Lords chamber. Use when you want real-time updates on Lords business, current debates, or voting activity.")]
         public async Task<McpToolResponse> HappeningNowInLordsAsync()
         {
             var url = $"{NowApiBase}/Message/message/LordsMain/current";
-            return await GetResult(url);
+            return await GetResult(url, CacheSettings.Disabled);
         }
     }
 }

--- a/OpenDataMcpServer.sln
+++ b/OpenDataMcpServer.sln
@@ -1,20 +1,46 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.36105.23 d17.13
+VisualStudioVersion = 17.13.36105.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenData.Mcp.Server", "OpenData.Mcp.Server\OpenData.Mcp.Server.csproj", "{652A04B9-CD30-47AB-8E35-FBF88441B1A9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenData.Mcp.Server.Tests", "OpenData.Mcp.Server.Tests\OpenData.Mcp.Server.Tests.csproj", "{478B05DE-0EB9-4446-AEB0-1025FD7847BD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Debug|x64.Build.0 = Debug|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Debug|x86.Build.0 = Debug|Any CPU
 		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Release|x64.ActiveCfg = Release|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Release|x64.Build.0 = Release|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Release|x86.ActiveCfg = Release|Any CPU
+		{652A04B9-CD30-47AB-8E35-FBF88441B1A9}.Release|x86.Build.0 = Release|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Debug|x64.Build.0 = Debug|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Debug|x86.Build.0 = Debug|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|x64.ActiveCfg = Release|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|x64.Build.0 = Release|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|x86.ActiveCfg = Release|Any CPU
+		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- allow per-request cache overrides and disable caching for Parliament Now endpoints
- expose raw JSON plus typed accessors via McpToolResponse
- add BaseTools/NowTools tests covering caching, retries, and error handling

## Testing
- dotnet build OpenDataMcpServer.sln -c Debug
- dotnet test OpenDataMcpServer.sln
