### PR TITLE
feat(http): add polly-based resiliency

### DIFF
--- a/OpenData.Mcp.Server.Tests/OpenData.Mcp.Server.Tests.csproj
+++ b/OpenData.Mcp.Server.Tests/OpenData.Mcp.Server.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/OpenData.Mcp.Server/Infrastructure/HttpClientPolicyFactory.cs
+++ b/OpenData.Mcp.Server/Infrastructure/HttpClientPolicyFactory.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Extensions.Http;
+
+namespace OpenData.Mcp.Server.Infrastructure;
+
+public static class HttpClientPolicyFactory
+{
+    public const string ClientName = "parliament-http";
+    public const int RetryCount = 3;
+    public const int CircuitBreakerFailureThreshold = 5;
+    public static readonly TimeSpan CircuitBreakerDuration = TimeSpan.FromSeconds(30);
+
+    public static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicy(ILogger logger)
+    {
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .OrResult(response => response.StatusCode == HttpStatusCode.TooManyRequests)
+            .WaitAndRetryAsync(
+                RetryCount,
+                retryAttempt => TimeSpan.FromMilliseconds(200 * Math.Pow(2, retryAttempt - 1)),
+                (outcome, timespan, attempt, context) =>
+                {
+                    var url = outcome.Result?.RequestMessage?.RequestUri?.ToString()
+                              ?? outcome.Exception?.GetBaseException().Message
+                              ?? "unknown";
+                    logger.LogWarning(
+                        "Transient HTTP failure for {Url}. Retry {Attempt} in {Delay}ms.",
+                        url,
+                        attempt,
+                        timespan.TotalMilliseconds);
+                });
+    }
+
+    public static IAsyncPolicy<HttpResponseMessage> CreateCircuitBreakerPolicy(ILogger logger)
+    {
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .OrResult(response => response.StatusCode == HttpStatusCode.TooManyRequests)
+            .CircuitBreakerAsync(
+                CircuitBreakerFailureThreshold,
+                CircuitBreakerDuration,
+                (outcome, breakDelay) =>
+                {
+                    var url = outcome.Result?.RequestMessage?.RequestUri?.ToString()
+                              ?? outcome.Exception?.GetBaseException().Message
+                              ?? "unknown";
+                    logger.LogWarning(
+                        "Circuit opened after failures for {Url}. Blocking for {Delay}s.",
+                        url,
+                        breakDelay.TotalSeconds);
+                },
+                () => logger.LogInformation("Circuit closed."),
+                () => logger.LogInformation("Circuit half-open."));
+    }
+}

--- a/OpenData.Mcp.Server/OpenData.Mcp.Server.csproj
+++ b/OpenData.Mcp.Server/OpenData.Mcp.Server.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.9" />
     <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.2" />
   </ItemGroup>
 

--- a/OpenData.Mcp.Server/Program.cs
+++ b/OpenData.Mcp.Server/Program.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenData.Mcp.Server.Infrastructure;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Logging.AddConsole(consoleLogOptions =>
@@ -10,6 +12,18 @@ builder.Logging.AddConsole(consoleLogOptions =>
 
 builder.Services.AddMcpServer().WithStdioServerTransport().WithToolsFromAssembly();
 builder.Services.AddMemoryCache();
-builder.Services.AddHttpClient();
+
+var httpClientBuilder = builder.Services.AddHttpClient(HttpClientPolicyFactory.ClientName);
+httpClientBuilder.ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(30));
+httpClientBuilder.AddPolicyHandler((services, _) =>
+{
+    var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("PollyRetry");
+    return HttpClientPolicyFactory.CreateRetryPolicy(logger);
+});
+httpClientBuilder.AddPolicyHandler((services, _) =>
+{
+    var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("PollyCircuit");
+    return HttpClientPolicyFactory.CreateCircuitBreakerPolicy(logger);
+});
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary
- configure the shared HttpClient with Polly retry and circuit-breaker policies and dedicated client name
- remove manual retry loop from BaseTools and handle circuit-breaker/network failures with structured errors
- add HttpClientPolicyFactory plus expanded unit tests covering retry, circuit-breaker, and caching behaviour

## Testing
- dotnet build OpenDataMcpServer.sln -c Debug
- dotnet test OpenDataMcpServer.sln

Closes #5
