### PR TITLE
test: add live parliament integration suite

### DIFF
--- a/OpenData.Mcp.Server.IntegrationTests/OpenData.Mcp.Server.IntegrationTests.csproj
+++ b/OpenData.Mcp.Server.IntegrationTests/OpenData.Mcp.Server.IntegrationTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenData.Mcp.Server\OpenData.Mcp.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OpenData.Mcp.Server.IntegrationTests/ParliamentApiIntegrationTests.cs
+++ b/OpenData.Mcp.Server.IntegrationTests/ParliamentApiIntegrationTests.cs
@@ -1,0 +1,112 @@
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using OpenData.Mcp.Server.Tools;
+using Xunit;
+using Xunit.Sdk;
+
+namespace OpenData.Mcp.Server.IntegrationTests;
+
+public class ParliamentApiIntegrationTests
+{
+    [ParliamentIntegrationFact]
+    public async Task BillsTools_ReturnsRecentBills()
+    {
+        using var provider = ParliamentIntegrationTestHost.CreateProvider();
+        var tools = provider.GetRequiredService<BillsTools>();
+
+        var response = await tools.GetRecentlyUpdatedBillsAsync(5);
+        AssertSuccess(response, nameof(BillsTools.GetRecentlyUpdatedBillsAsync));
+
+        AssertJsonArray(response.Json, "recent bills");
+    }
+
+    [ParliamentIntegrationFact]
+    public async Task BillsTools_ReturnsBillTypes()
+    {
+        using var provider = ParliamentIntegrationTestHost.CreateProvider();
+        var tools = provider.GetRequiredService<BillsTools>();
+
+        var response = await tools.BillTypesAsync();
+        AssertSuccess(response, nameof(BillsTools.BillTypesAsync));
+
+        AssertJsonArray(response.Json, "bill types");
+    }
+
+    [ParliamentIntegrationFact]
+    public async Task MembersTools_ReturnsAnsweringBodies()
+    {
+        using var provider = ParliamentIntegrationTestHost.CreateProvider();
+        var tools = provider.GetRequiredService<MembersTools>();
+
+        var response = await tools.GetAnsweringBodiesAsync();
+        AssertSuccess(response, nameof(MembersTools.GetAnsweringBodiesAsync));
+
+        AssertJsonArray(response.Json, "answering bodies");
+    }
+
+    [ParliamentIntegrationFact]
+    public async Task MembersTools_SearchMembers()
+    {
+        using var provider = ParliamentIntegrationTestHost.CreateProvider();
+        var tools = provider.GetRequiredService<MembersTools>();
+
+        var response = await tools.SearchMembersAsync(name: "Johnson");
+        AssertSuccess(response, nameof(MembersTools.SearchMembersAsync));
+
+        AssertJsonArray(response.Json, "member search results");
+    }
+
+    [ParliamentIntegrationFact]
+    public async Task NowTools_CommonsFeedResponds()
+    {
+        using var provider = ParliamentIntegrationTestHost.CreateProvider();
+        var tools = provider.GetRequiredService<NowTools>();
+
+        var response = await tools.HappeningNowInCommonsAsync();
+        AssertSuccess(response, nameof(NowTools.HappeningNowInCommonsAsync));
+
+        Assert.False(string.IsNullOrWhiteSpace(response.RawContent));
+    }
+
+    private static void AssertSuccess(McpToolResponse response, string operation)
+    {
+        if (!response.Success)
+        {
+            var message = $"{operation} failed with status {response.StatusCode}: {response.Error}";
+            throw new XunitException(message);
+        }
+
+        Assert.False(string.IsNullOrWhiteSpace(response.RawContent));
+    }
+
+    private static void AssertJsonArray(JsonElement? element, string description)
+    {
+        if (element is not JsonElement jsonElement)
+        {
+            throw new XunitException($"{description} payload missing or not JSON.");
+        }
+
+        if (jsonElement.ValueKind == JsonValueKind.Object)
+        {
+            if (!jsonElement.EnumerateObject().Any())
+            {
+                throw new XunitException($"{description} payload empty.");
+            }
+
+            return;
+        }
+
+        if (jsonElement.ValueKind == JsonValueKind.Array)
+        {
+            if (!jsonElement.EnumerateArray().Any())
+            {
+                throw new XunitException($"{description} array empty.");
+            }
+
+            return;
+        }
+
+        throw new XunitException($"Unexpected JSON shape for {description}: {jsonElement.ValueKind}");
+    }
+}

--- a/OpenData.Mcp.Server.IntegrationTests/ParliamentIntegrationFactAttribute.cs
+++ b/OpenData.Mcp.Server.IntegrationTests/ParliamentIntegrationFactAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+using Xunit;
+
+namespace OpenData.Mcp.Server.IntegrationTests;
+
+/// <summary>
+/// Marks integration tests that require live Parliament APIs.
+/// Tests are skipped unless RUN_PARLIAMENT_INTEGRATION_TESTS=true.
+/// </summary>
+public sealed class ParliamentIntegrationFactAttribute : FactAttribute
+{
+    private const string EnvVar = "RUN_PARLIAMENT_INTEGRATION_TESTS";
+
+    public ParliamentIntegrationFactAttribute()
+    {
+        var flag = Environment.GetEnvironmentVariable(EnvVar);
+        if (!string.Equals(flag, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            Skip = $"Skipped. Set {EnvVar}=true to run live Parliament integration tests.";
+        }
+    }
+}

--- a/OpenData.Mcp.Server.IntegrationTests/ParliamentIntegrationTestHost.cs
+++ b/OpenData.Mcp.Server.IntegrationTests/ParliamentIntegrationTestHost.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenData.Mcp.Server.Infrastructure;
+using OpenData.Mcp.Server.Tools;
+
+namespace OpenData.Mcp.Server.IntegrationTests;
+
+internal static class ParliamentIntegrationTestHost
+{
+    public static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddLogging(builder => builder.AddConsole());
+        services.AddMemoryCache();
+
+        services.AddHttpClient(HttpClientPolicyFactory.ClientName)
+            .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(30))
+            .AddPolicyHandler((sp, _) =>
+            {
+                var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("PollyRetry");
+                return HttpClientPolicyFactory.CreateRetryPolicy(logger);
+            })
+            .AddPolicyHandler((sp, _) =>
+            {
+                var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("PollyCircuit");
+                return HttpClientPolicyFactory.CreateCircuitBreakerPolicy(logger);
+            });
+
+        services.AddTransient<BillsTools>();
+        services.AddTransient<MembersTools>();
+        services.AddTransient<NowTools>();
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/OpenData.Mcp.Server.IntegrationTests/README.md
+++ b/OpenData.Mcp.Server.IntegrationTests/README.md
@@ -1,0 +1,12 @@
+# OpenData.Mcp.Server Integration Tests
+
+These tests exercise the live UK Parliament APIs via the MCP tool classes. They are **skipped by default** to avoid network traffic during normal development and CI runs.
+
+## Running locally
+
+`powershell
+ = 'true'
+dotnet test OpenDataMcpServer.sln
+`
+
+Any value other than 	rue (case-insensitive) keeps the tests skipped.

--- a/OpenDataMcpServer.sln
+++ b/OpenDataMcpServer.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenData.Mcp.Server", "Open
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenData.Mcp.Server.Tests", "OpenData.Mcp.Server.Tests\OpenData.Mcp.Server.Tests.csproj", "{478B05DE-0EB9-4446-AEB0-1025FD7847BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenData.Mcp.Server.IntegrationTests", "OpenData.Mcp.Server.IntegrationTests\OpenData.Mcp.Server.IntegrationTests.csproj", "{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,18 @@ Global
 		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|x64.Build.0 = Release|Any CPU
 		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|x86.ActiveCfg = Release|Any CPU
 		{478B05DE-0EB9-4446-AEB0-1025FD7847BD}.Release|x86.Build.0 = Release|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Debug|x64.Build.0 = Debug|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Debug|x86.Build.0 = Debug|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Release|x64.ActiveCfg = Release|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Release|x64.Build.0 = Release|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Release|x86.ActiveCfg = Release|Any CPU
+		{845187DF-4F6B-4F60-950A-D2BCB0B1E14B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add OpenData.Mcp.Server.IntegrationTests project with environment-gated [ParliamentIntegrationFact]
- exercise real Bills, Members, and Now tool endpoints using the production HttpClient configuration
- document RUN_PARLIAMENT_INTEGRATION_TESTS usage for opt-in live testing

## Testing
- dotnet test OpenDataMcpServer.sln

Closes #7
