### PR TITLE
ci: schedule weekly live integration tests

### DIFF
--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -1,0 +1,27 @@
+name: Live Integration Tests
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RUN_PARLIAMENT_INTEGRATION_TESTS: 'true'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore OpenDataMcpServer.sln
+
+      - name: Run integration suite
+        run: dotnet test OpenDataMcpServer.sln --configuration Release --logger "trx"

--- a/OpenData.Mcp.Server.IntegrationTests/README.md
+++ b/OpenData.Mcp.Server.IntegrationTests/README.md
@@ -10,3 +10,5 @@ dotnet test OpenDataMcpServer.sln
 `
 
 Any value other than 	rue (case-insensitive) keeps the tests skipped.
+
+These tests also run weekly via the Live Integration Tests GitHub Actions workflow (cron at 03:00 UTC on Mondays).


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs every Monday at 03:00 UTC (and via manual dispatch)
- set RUN_PARLIAMENT_INTEGRATION_TESTS=true so the live suite executes against real Parliament APIs
- mention the scheduled workflow in the integration test README for developer awareness

## Testing
- dotnet test OpenDataMcpServer.sln
